### PR TITLE
Only apply the require shim on server.

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,8 +8,8 @@ Package.on_use(function (api, where) {
   if (api.imply) {
     api.imply("moment", where);
   }
-  api.add_files('require-shim.js', where);
+  api.add_files('require-shim.js', 'server');
   api.add_files('lib/moment-timezone/moment-timezone.js', where);
   api.add_files('lib/moment-timezone-data/moment-timezone-data.js', where);
-  api.add_files('revert-require-shim.js', where);
+  api.add_files('revert-require-shim.js', 'server');
 });


### PR DESCRIPTION
It would seem that when the require shim is loaded in on the client side it does more harm than good. Moment and moment-timezone are equipped to handle being simply thrown into a document's namespace (mainly by using the <script> tag, but minification also works) and they sort themselves out fine.
